### PR TITLE
Changed the bike station info pin from `rds` to `csv`.

### DIFF
--- a/content/01-etl/01-raw-data-refresh/document.qmd
+++ b/content/01-etl/01-raw-data-refresh/document.qmd
@@ -106,6 +106,7 @@ board <- pins::board_rsconnect(
 pins::pin_write(
   board,
   x = station_info,
+  type = "csv",
   name = "bike-predict-r-station-info-pin",
   title = "Bike Predict - ETL - Pinned Station Info",
   description = "Bike station info from https://capitalbikeshare.com."


### PR DESCRIPTION
Changed the bike station info pin (<https://colorado.rstudio.com/rsc/bike-predict-r-station-info-data-pin/>) from `.rds` to `.csv` so that it can be read into a Pandas DataFrame for the python workflow.